### PR TITLE
Fixed: websocket.serve failed to bind to "localhost"

### DIFF
--- a/live/plugin.py
+++ b/live/plugin.py
@@ -206,7 +206,7 @@ class LiveEditPlugin(BasePlugin):
         """The event loop of the websocket server."""
         async with serve(
             self.websocket_receiver,
-            "localhost",
+            "127.0.0.1",
             self.config['websockets_port']
         ):
             self.log.info(


### PR DESCRIPTION
https://websockets.readthedocs.io/en/stable/faq/server.html#what-does-oserror-errno-99-error-while-attempting-to-bind-on-address-1-80-0-0-address-not-available-mean