### PR TITLE
Allow hidden Edit button

### DIFF
--- a/live/live-edit.js
+++ b/live/live-edit.js
@@ -26,7 +26,6 @@ function websocket_connect(hostname, port) {
 (function () {
   let
     ws = undefined,
-    wsConnected = websocket_connect(window.location.hostname, ws_port),
     domLoaded = new Promise(function (resolve) {
       document.addEventListener('DOMContentLoaded', resolve);
     }),
@@ -43,6 +42,7 @@ function websocket_connect(hostname, port) {
   le_log('live-edit: page_base_path:', page_base_path);
 
   domLoaded.then(() => {
+    const wsConnected = websocket_connect(window.location.hostname, ws_port);
     wsConnected
       .then(wso => {
         le_log('Connected to live-edit server');


### PR DESCRIPTION
Hi, I would like to be able to preview mkdocs pages unchanged and still have editing functionality available.
So this pull requests does two things:
1. Add accesskey to all buttons, similar to how Wikipedia has `<a title="Edit this page [e]" accesskey="e">`
2. Add a CSS class `live-edit-editing` to the outer div during edit mode.

This allows me to preview pages without any edit controls but still enter edit mode with pressing Shift+Alt+E, by using a custom CSS snippet:
```css
.md-content article .live-edit-controls:not(.live-edit-editing) {
  width: 0; height: 0; overflow: hidden;
  border: 0; margin: 0; padding: 0;
}
```