### PR TITLE
Support user_docs_dir alternative to docs_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ plugins:
       # This string is directly fed into the document.querySelector function:
       # https://developer.mozilla.org/en-US/docs/Web/API/Element/querySelector
       article_selector: 'div.my-custom-class'
+      # Some plugins (e.g. mkdocs-monorepo-plugin) create a temporary docs_dir
+      # which breaks live-edit. Use user_docs_dir to specify the real docs path:
+      user_docs_dir: /path/to/real/user/docs
 ```
 
 ## How Does it Work?
@@ -85,6 +88,16 @@ A similar mechanism is in place for other operations like renaming and deleting.
 #### ⚠️ "Could not find article element to prepend controls!"
 
 The plugin was unable to automatically determine the element which houses the text of your article. You can use the `article_selector` setting to provide the correct selector syntaxt used by the [`querySelector`](https://developer.mozilla.org/en-US/docs/Web/API/Element/querySelector) function to find your article. This should be the parent element of your article's H1 tag, containing all of your article's text.
+
+#### ⚠️ Live-edit doesn't work with mkdocs-monorepo-plugin (or similar plugins)
+
+Some plugins create a temporary `docs_dir` which breaks live-edit. Use the `user_docs_dir` option to specify the real path to your documentation source files:
+
+```yml
+plugins:
+  - live-edit:
+      user_docs_dir: /path/to/real/user/docs
+```
 
 ## Changelog
 

--- a/live/plugin.py
+++ b/live/plugin.py
@@ -43,6 +43,7 @@ class LiveEditPlugin(BasePlugin):
         ('websockets_timeout', config_options.Type(int, default=10)),
         ('debug_mode', config_options.Type(bool, default=False)),
         ('article_selector', config_options.Type(string, default=None)),
+        ('user_docs_dir', config_options.Type(str, default=None)),
     )
     log: Logger = getLogger(f'mkdocs.plugins.{__name__}')
     server_thread: Optional[threading.Thread] = None
@@ -56,6 +57,15 @@ class LiveEditPlugin(BasePlugin):
         "new_url": None,
     }
 
+    def _get_docs_dir(self) -> Path:
+        """Returns the effective docs_dir: user_docs_dir if set, otherwise cfg['docs_dir']."""
+        if self.config.get('user_docs_dir'):
+            return Path(self.config['user_docs_dir'])
+        docs_dir = self.mkdocs_config.get('docs_dir')
+        if docs_dir is None:
+            raise TypeError('docs_dir is None')
+        return Path(docs_dir)
+
     def __init__(self):
         """Initializes the plugin."""
         parent_dir = Path(__file__).parent
@@ -68,26 +78,24 @@ class LiveEditPlugin(BasePlugin):
 
     def read_file_contents(self, path: str) -> str:
         """Reads the contents of a page from the filesystem."""
-        with open(Path(self.mkdocs_config['docs_dir']) / path, 'r', encoding='utf-8') as file:
+        with open(self._get_docs_dir() / path, 'r', encoding='utf-8') as file:
             return file.read()
 
     def write_file_contents(self, path: str, contents: str) -> None:
         """Writes the contents of a page to the filesystem."""
-        with open(Path(self.mkdocs_config['docs_dir']) / path, 'w', encoding='utf-8') as file:
+        with open(self._get_docs_dir() / path, 'w', encoding='utf-8') as file:
             file.write(contents)
 
     def rename_file(self, old_filepath: str, new_filename: str) -> str:
         """Renames a file on the filesystem."""
         try:
             cfg = self.mkdocs_config
-            if cfg['docs_dir'] is None:
-                raise TypeError('docs_dir is None')
-            docs_dir = Path(cfg['docs_dir'])
+            docs_dir = self._get_docs_dir()
             old_path = docs_dir / old_filepath
             new_path = old_path.rename(old_path.parent / new_filename)
             new_page = Page(None, File(
                 str(new_path.relative_to(docs_dir)),
-                cfg['docs_dir'],
+                str(docs_dir),
                 cfg['site_dir'],
                 cfg['use_directory_urls']
             ), cfg)
@@ -115,10 +123,7 @@ class LiveEditPlugin(BasePlugin):
     def delete_file(self, path: str) -> str:
         """Deletes a file on the filesystem."""
         try:
-            cfg = self.mkdocs_config
-            if cfg['docs_dir'] is None:
-                raise TypeError('docs_dir is None')
-            docs_dir = Path(cfg['docs_dir'])
+            docs_dir = self._get_docs_dir()
             (docs_dir / path).unlink()
             return json.dumps({
                 'action':   'delete_file',
@@ -163,7 +168,7 @@ class LiveEditPlugin(BasePlugin):
     def create_new_file(self, path: str, title: str) -> str:
         """Creates a new file and returns a JSON string describing the result."""
         try:
-            new_path = Path(self.mkdocs_config['docs_dir']) / path
+            new_path = self._get_docs_dir() / path
             # ensure the parent directory structure exists
             if not new_path.parent.exists():
                 new_path.parent.mkdir(parents=True)
@@ -286,7 +291,7 @@ class LiveEditPlugin(BasePlugin):
         """Here we try to discern the new URL of a page that was just created."""
         if self.new_page["created_file"] is None or (self.new_page["new_url"] is not None):
             return page
-        path = Path(self.mkdocs_config['docs_dir']) / page.file.src_path
+        path = self._get_docs_dir() / page.file.src_path
         if Path.samefile(path, self.new_page["created_file"]):
             self.log.info('new page created: %s', page.abs_url)
             self.new_page["new_url"] = page.abs_url


### PR DESCRIPTION
Some plugins create a custom docs_dir and override the mkdocs config `docs_dir` which breaks this plugin.

closes #18