### PR TITLE
Style now taken from theme elements

### DIFF
--- a/live/live-edit.css
+++ b/live/live-edit.css
@@ -7,12 +7,12 @@
   height: 50vh;
   resize: vertical;
   /** make it readable **/
-  font-family: monospace;
+  font-family: var(--md-code-font-family, monospace);
   font-size: .8rem;
   line-height: 1.5;
-  color: #333;
-  background: #fff;
-  border: 1px solid #ccc;
+  color: var(--md-default-fg-color, #333);
+  background: var(--md-default-bg-color, #fff);
+  border: 1px solid var(--md-default-fg-color--lightest, #ccc);
   border-radius: 3px;
   padding: 5px 10px;
   margin: 5px;
@@ -44,15 +44,20 @@ button.live-edit-pencil-button {
 
 button.live-edit-button {
   cursor: pointer;
-  background: #fff;
-  border: 1px solid #ccc;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 3px;
   padding: 5px 10px;
   margin: 0 5px;
   font-size: .8rem;
   line-height: 1.5;
-  color: #333;
+  color: var(--md-primary-bg-color, #fff);
   outline: none;
+  transition: background .2s;
+}
+
+button.live-edit-button:hover {
+  background: rgba(255, 255, 255, 0.25);
 }
 
 button.live-edit-button.align-right {
@@ -65,15 +70,28 @@ button.live-edit-save-button {
   color: #fff;
 }
 
+button.live-edit-save-button:hover {
+  background: #4cae4c;
+}
+
 button.live-edit-cancel-button {
   background: #d9534f;
   border-color: #d43f3a;
   color: #fff;
 }
 
+button.live-edit-cancel-button:hover {
+  background: #d43f3a;
+}
+
 div.live-edit-controls {
-  background-color: #fff2dc;
-  border: 1px solid #f0c36d;
+  background: linear-gradient(
+    to bottom,
+    var(--md-primary-fg-color, #fff2dc),
+    var(--md-footer-bg-color, #f0c36d)
+  );
+  border: 1px solid var(--md-primary-fg-color--dark, #f0c36d);
+  color: var(--md-primary-bg-color, inherit);
   border-radius: 3px;
   padding: 5px 10px;
   margin: 10px 0;
@@ -87,6 +105,7 @@ div.live-edit-controls {
   text-align: right;
   margin-right: 10px;
   font-size: .8rem;
+  color: var(--md-primary-bg-color, inherit);
 }
 
 .live-edit-modal {
@@ -105,8 +124,8 @@ div.live-edit-controls {
 }
 
 .live-edit-info-modal {
-  background-color: #fff2dc;
-  border: 1px solid #f0c36d;
+  background-color: var(--md-default-bg-color--light, #fff2dc);
+  border: 1px solid var(--md-default-fg-color--lightest, #f0c36d);
 }
 
 .live-edit-error-message-dialog {

--- a/live/live-edit.js
+++ b/live/live-edit.js
@@ -1,5 +1,71 @@
 const le_log = !debug_mode ? function () { } : (...args) => console.log('live-edit:', ...args);
 
+function _detectThemeVars() {
+  var cs = getComputedStyle(document.documentElement);
+  if (cs.getPropertyValue('--md-primary-fg-color').trim()) return;
+
+  function _parseRgb(str) {
+    if (!str) return null;
+    var m = str.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+    return m ? { r: +m[1], g: +m[2], b: +m[3] } : null;
+  }
+  function _lum(r, g, b) {
+    var a = [r, g, b].map(function (v) {
+      v /= 255;
+      return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+    });
+    return 0.2126 * a[0] + 0.7152 * a[1] + 0.0722 * a[2];
+  }
+  function _darken(rgb, f) {
+    var s = 1 - (f || 0.15);
+    return 'rgb(' + Math.round(rgb.r * s) + ',' + Math.round(rgb.g * s) + ',' + Math.round(rgb.b * s) + ')';
+  }
+  function _lighten(rgb, f) {
+    f = f || 0.15;
+    return 'rgb(' +
+      Math.round(rgb.r + (255 - rgb.r) * f) + ',' +
+      Math.round(rgb.g + (255 - rgb.g) * f) + ',' +
+      Math.round(rgb.b + (255 - rgb.b) * f) + ')';
+  }
+  function _alpha(rgb, a) {
+    return 'rgba(' + rgb.r + ',' + rgb.g + ',' + rgb.b + ',' + a + ')';
+  }
+  function _isLight(rgb) {
+    return rgb && _lum(rgb.r, rgb.g, rgb.b) > 0.4;
+  }
+
+  var root = document.documentElement;
+  var navbar = document.body.children[0];
+  if (navbar && navbar.nodeType === 1) {
+    var navCs = getComputedStyle(navbar);
+    var navBgRgb = _parseRgb(navCs.backgroundColor);
+    var navFgRgb = _parseRgb(navCs.color);
+    if (navBgRgb) {
+      root.style.setProperty('--md-primary-fg-color', navCs.backgroundColor);
+      root.style.setProperty('--md-primary-fg-color--dark', _darken(navBgRgb, 0.15));
+      root.style.setProperty('--md-footer-bg-color', _darken(navBgRgb, 0.1));
+    }
+    if (navFgRgb) {
+      root.style.setProperty('--md-primary-bg-color', navCs.color);
+    }
+  }
+
+  var bodyCs = getComputedStyle(document.body);
+  var bodyBgRgb = _parseRgb(bodyCs.backgroundColor);
+  var bodyFgRgb = _parseRgb(bodyCs.color);
+  if (bodyBgRgb) {
+    root.style.setProperty('--md-default-bg-color', bodyCs.backgroundColor);
+    root.style.setProperty('--md-default-bg-color--light',
+      _isLight(bodyBgRgb) ? _darken(bodyBgRgb, 0.04) : _lighten(bodyBgRgb, 0.06));
+  }
+  if (bodyFgRgb) {
+    root.style.setProperty('--md-default-fg-color', bodyCs.color);
+    root.style.setProperty('--md-default-fg-color--lightest', _alpha(bodyFgRgb, 0.12));
+  }
+
+  root.style.setProperty('--md-code-font-family', bodyCs.fontFamily || 'monospace');
+}
+
 // connect to the specified websocket server. retry 3 times with a 1 second delay
 function websocket_connect(hostname, port) {
   return new Promise(function (resolve, reject) {
@@ -380,6 +446,7 @@ function websocket_connect(hostname, port) {
     le_log(message);
     domLoaded
       .then(() => {
+        _detectThemeVars();
         controls = document.createElement('div');
         controls.className = 'live-edit-controls';
         // add a label to the controls


### PR DESCRIPTION
Prioritizes CSS variables from the theme but falls back to default values if the variables are not availabl.e

Screenshot live bar (light/dark)
-------------------

<img width="2540" height="410" alt="image" src="https://github.com/user-attachments/assets/25853222-c4fe-45ad-82a3-4976ed42b035" />

<img width="2692" height="526" alt="image" src="https://github.com/user-attachments/assets/3b8ac3bb-4f5a-475c-8b2d-924be57a5db3" />

Screenshot of expanded live bar (light/dark)
-------------------------------

**Note:** ignore the Disable Editor button.  That was added by the WYSIWYG plugin.

<img width="2724" height="1384" alt="image" src="https://github.com/user-attachments/assets/acd7ac5f-7a99-4236-a4a0-380fbd3feb76" />

<img width="2814" height="1480" alt="image" src="https://github.com/user-attachments/assets/8a301a96-ff83-4afb-bb49-f1a94e06b5aa" />
